### PR TITLE
12 cores limit when parallelizing

### DIFF
--- a/R/FMM_internal.R
+++ b/R/FMM_internal.R
@@ -338,7 +338,7 @@ getApply <- function(parallelize = FALSE){
     return(usedApply)
   }
 
-  nCores <- parallel::detectCores() - 1
+  nCores <- min(12, parallel::detectCores() - 1)
 
   if(parallelize){
     # different ways to implement parallelization depending on OS:


### PR DESCRIPTION
### Parallelizing:
Number of cores (`FMM_internal.R/getApply(...)`: variable `nCores`) on parallelizing fixed (max: 12).