### PR TITLE
Optim check

### DIFF
--- a/R/fitFMM_unit.R
+++ b/R/fitFMM_unit.R
@@ -37,8 +37,7 @@ fitFMM_unit <- function(vData, timePoints = seqTimes(length(vData)),
 
   ## Step 2: BFGS optimization. 'step2FMM' function is used.
   BFGS <- optim(par = bestPar[1:5], fn = step2FMM, vData = vData,
-                      timePoints = timePoints, omegaMax = omegaMax,
-                      method = "BFGS")
+                timePoints = timePoints, omegaMax = omegaMax, method = "BFGS")
   parFinal <- BFGS$par
 
   # alpha and beta between 0 and 2pi
@@ -80,8 +79,7 @@ fitFMM_unit <- function(vData, timePoints = seqTimes(length(vData)),
 
     ## Step 2: BFGS optimization
     BFGS <- optim(par = bestPar[1:5], fn = step2FMM, vData = vData,
-                        timePoints = timePoints, omegaMax = omegaMax,
-                        method = "BFGS")
+                  timePoints = timePoints, omegaMax = omegaMax, method = "BFGS")
     parFinal <- BFGS$par
 
     # alpha and beta between 0 and 2pi

--- a/R/fitFMM_unit.R
+++ b/R/fitFMM_unit.R
@@ -35,11 +35,11 @@ fitFMM_unit <- function(vData, timePoints = seqTimes(length(vData)),
   # We use bestStep1 internal function
   bestPar <- bestStep1(vData, step1)
 
-  ## Step 2: Nelder-Mead optimization. 'step2FMM' function is used.
-  nelderMead <- optim(par = bestPar[1:5], fn = step2FMM, vData = vData,
-                      timePoints = timePoints, omegaMax = omegaMax)
-  parFinal <- nelderMead$par
-  SSE <- nelderMead$value*n
+  ## Step 2: BFGS optimization. 'step2FMM' function is used.
+  BFGS <- optim(par = bestPar[1:5], fn = step2FMM, vData = vData,
+                      timePoints = timePoints, omegaMax = omegaMax,
+                      method = "BFGS")
+  parFinal <- BFGS$par
 
   # alpha and beta between 0 and 2pi
   parFinal[3] <- parFinal[3]%%(2*pi)
@@ -78,10 +78,11 @@ fitFMM_unit <- function(vData, timePoints = seqTimes(length(vData)),
       warning("FMM model may be no appropiate")
     }
 
-    ## Step 2: Nelder-Mead optimization
-    nelderMead <- optim(par = bestPar[1:5], fn = step2FMM, vData = vData,
-                        timePoints = timePoints, omegaMax = omegaMax)
-    parFinal <- nelderMead$par
+    ## Step 2: BFGS optimization
+    BFGS <- optim(par = bestPar[1:5], fn = step2FMM, vData = vData,
+                        timePoints = timePoints, omegaMax = omegaMax,
+                        method = "BFGS")
+    parFinal <- BFGS$par
 
     # alpha and beta between 0 and 2pi
     parFinal[3] <- parFinal[3] %% (2*pi)


### PR DESCRIPTION
### Optim function call :
Changes:
- In `optim(...)` call: `method = BFGS` used instead of `Nelder-Mead` (default).
- `nelderMead` variable has been renamed (`BFGS`).
-  A *SSE* value was calculated after the first `optim` call, but it was not used. Due to this reason, it has been removed.

> **Note:** `method = L-BFGS-B` can be useful in order to restrict some parameters, or maybe restrict omega between 0 and 1 in the `optim(...)` function call instead of in `step2FMM(...)`.
