### PR TITLE
Fmm revision

### DIFF
--- a/R/FMM_internal.R
+++ b/R/FMM_internal.R
@@ -223,7 +223,7 @@ calculateCosPhi <- function(alpha, beta, omega, timePoints){
 # Internal function: returns the parallelized apply function depending on the OS.
 # Returns the apply function to be used.
 ################################################################################
-getApply <- function(parallelize = FALSE, nCores = min(12, parallel::detectCores() - 1)){
+getApply <- function(parallelize = FALSE){
 
   getApply_Rbase <- function(){
     usedApply <- function(FUN, X, ...) t(apply(X = X, MARGIN = 1, FUN = FUN, ...))
@@ -243,6 +243,8 @@ getApply <- function(parallelize = FALSE, nCores = min(12, parallel::detectCores
     }
     return(usedApply)
   }
+
+  nCores <- min(12, parallel::detectCores() - 1)
 
   if(parallelize){
     # different ways to implement parallelization depending on OS:

--- a/R/FMM_internal.R
+++ b/R/FMM_internal.R
@@ -140,7 +140,7 @@ step2FMM <- function(parameters, vData, timePoints, omegaMax){
 
   # Other integrity conditions that must be met
   rest3 <- parameters[2] > 0  # A > 0
-  rest4 <- parameters[5] > 0  &  parameters[5] <= omegaMax # omega > 0 and omega <= omegaMax
+  rest4 <- parameters[5] > 0  &  parameters[5] <= omegaMax # omega in (0, 1]
   if(rest1 & rest2 & rest3 & rest4)
     return(residualSS)
   else

--- a/R/FMM_internal_restr.R
+++ b/R/FMM_internal_restr.R
@@ -91,7 +91,7 @@ backfittingRestr <- function(vData, omegas, nback, betaRestrictions,
       fittedFMMPerComponent[[j]] <- fitFMM_unit_restr(backFittingData, omegas[j], timePoints = timePoints,
                                                       lengthAlphaGrid = lengthAlphaGrid, alphaGrid = alphaGrid[[j]],
                                                       numReps = numReps)
-      fittedValuesPerComponent[,j] <- fittedFMMPerComponent[[j]]@fittedValues
+      fittedValuesPerComponent[,j] <- getFittedValues(fittedFMMPerComponent[[j]])
     }
 
     # Check stop criterion

--- a/R/FMM_internal_restr.R
+++ b/R/FMM_internal_restr.R
@@ -130,7 +130,7 @@ backfittingRestr <- function(vData, omegas, nback, betaRestrictions,
     distance[markedBetas == 1] <- Inf
     nearestBetasIndex <- order(distance)[1:numComponents]
     markedBetas[nearestBetasIndex] <- 1
-    restBeta[nearestBetasIndex] <- angularmean(restBeta[nearestBetasIndex])%%(2*pi)
+    restBeta[nearestBetasIndex] <- angularMean(restBeta[nearestBetasIndex])%%(2*pi)
   }
 
   # A and M estimates are recalculated by linear regression

--- a/R/extractWaves.R
+++ b/R/extractWaves.R
@@ -26,14 +26,14 @@
 #' extractWaves(fit)
 #'
 extractWaves <- function(objFMM){
-   nComponents <- length(objFMM@alpha)
-   timePoints <- objFMM@timePoints
-   firstValue <- objFMM@data[1]
+   nComponents <- length(getAlpha(objFMM))
+   timePoints <- getTimePoints(objFMM)
+   firstValue <- getData(objFMM)[1]
    predicted <- list()
 
    for(i in 1:nComponents){
-     predictedComponent <- objFMM@A[i]*calculateCosPhi(objFMM@alpha[i], objFMM@beta[i],
-                                                       objFMM@omega[i], timePoints)
+     predictedComponent <- getA(objFMM)[i]*calculateCosPhi(getAlpha(objFMM)[i], getBeta(objFMM)[i],
+                                                       getOmega(objFMM)[i], timePoints)
      predicted[[i]] <- predictedComponent - predictedComponent[1] + firstValue
    }
    return(predicted)

--- a/R/extractWaves.R
+++ b/R/extractWaves.R
@@ -13,7 +13,7 @@
 #'
 #' @examples
 #' ## Generate example data:
-#' fmm2.data <- generateFMM(M = 0, A = rep(2,1),
+#' fmm2.data <- generateFMM(M = 0, A = rep(1, 2),
 #'                          alpha = c(1.5, 3.4), beta = c(0.2, 2.3), omega = c(0.1, 0.2),
 #'                          plot = FALSE, outvalues = TRUE,
 #'                          sigmaNoise = 0.5) # add a gaussian noise with sigma = 0.5
@@ -26,16 +26,15 @@
 #' extractWaves(fit)
 #'
 extractWaves <- function(objFMM){
-   nComponents <- length(getAlpha(objFMM))
-   timePoints <- getTimePoints(objFMM)
-   firstValue<-getData(objFMM)[1]
-
+   nComponents <- length(objFMM@alpha)
+   timePoints <- objFMM@timePoints
+   firstValue <- objFMM@data[1]
    predicted <- list()
 
    for(i in 1:nComponents){
-     predictedi <- getA(objFMM)[i]*cos(getBeta(objFMM)[i] + 2*atan(getOmega(objFMM)[i]*tan((timePoints-getAlpha(objFMM)[i])/2)))
-     predicted[[i]] <- predictedi - predictedi[1] + firstValue
+     predictedComponent <- objFMM@A[i]*calculateCosPhi(objFMM@alpha[i], objFMM@beta[i],
+                                                       objFMM@omega[i], timePoints)
+     predicted[[i]] <- predictedComponent - predictedComponent[1] + firstValue
    }
-
    return(predicted)
 }

--- a/R/fitFMM.R
+++ b/R/fitFMM.R
@@ -117,9 +117,6 @@ fitFMM <- function(vData, nPeriods = 1, timePoints = NULL,
   omegaMax <- 1
   omegaGrid <- exp(seq(log(omegaMin),log(omegaMax),length.out = lengthOmegaGrid))
 
-  staticComponents <- NULL
-  objectFMM <- NULL
-
   betaOmegaRestrictions <- sort(betaOmegaRestrictions)
 
   if(showTime) time.ini <- Sys.time()
@@ -129,7 +126,6 @@ fitFMM <- function(vData, nPeriods = 1, timePoints = NULL,
     n <- length(vData)
     if(n %% nPeriods != 0) stop("Data length is not a multiple of nPeriods")
     dataMatrix <- matrix(vData, nrow = nPeriods, ncol = n/nPeriods, byrow = TRUE)
-    #vDataAnt <- vData
     summarizedData <- apply(dataMatrix, 2, mean)
   } else {
     summarizedData <- vData
@@ -203,6 +199,7 @@ fitFMM <- function(vData, nPeriods = 1, timePoints = NULL,
   fittedFMM@nPeriods <- nPeriods
   fittedFMM@data <- vData
 
+  # Reorder components by explained variability
   explainedVarOrder <- order(getR2(fittedFMM),decreasing = TRUE)
 
   fittedFMM@A <- getA(fittedFMM)[explainedVarOrder]
@@ -212,8 +209,7 @@ fitFMM <- function(vData, nPeriods = 1, timePoints = NULL,
   fittedFMM@R2 <- getR2(fittedFMM)[explainedVarOrder]
 
   # Restricted algorithm may find models with A<0
-  needFix <- which(getA(fittedFMM) < 0)
-  if(length(needFix)>0) {
+  if(any(getA(fittedFMM) < 0)) {
     stop("Invalid solution: check function input parameters.")
   }
 

--- a/R/fitFMM.R
+++ b/R/fitFMM.R
@@ -206,7 +206,8 @@ fitFMM <- function(vData, nPeriods = 1, timePoints = NULL,
   fittedFMM@alpha <- getAlpha(fittedFMM)[explainedVarOrder]
   fittedFMM@beta <- getBeta(fittedFMM)[explainedVarOrder]
   fittedFMM@omega <- getOmega(fittedFMM)[explainedVarOrder]
-  fittedFMM@R2 <- getR2(fittedFMM)[explainedVarOrder]
+  fittedFMM@R2 <- PVj(getData(fittedFMM), timePoints, getAlpha(fittedFMM), getBeta(fittedFMM),
+                      getOmega(fittedFMM))
 
   # Restricted algorithm may find models with A<0
   if(any(getA(fittedFMM) < 0)) {

--- a/R/fitFMM.R
+++ b/R/fitFMM.R
@@ -148,12 +148,7 @@ fitFMM <- function(vData, nPeriods = 1, timePoints = NULL,
   }
 
   # Used apply function for compute FMM models
-  if(length(unique(betaOmegaRestrictions)) != nback && !parallelize){
-    usedApply_Cluster <- getApply(parallelize = TRUE, nCores = 1)
-  }else{
-    usedApply_Cluster <- getApply(parallelize = parallelize)
-  }
-
+  usedApply_Cluster <- getApply(parallelize = parallelize)
   usedApply <- usedApply_Cluster[[1]]
 
   ### fitFMM_unit
@@ -208,16 +203,16 @@ fitFMM <- function(vData, nPeriods = 1, timePoints = NULL,
   fittedFMM@nPeriods <- nPeriods
   fittedFMM@data <- vData
 
-  explainedVarOrder <- order(fittedFMM@R2,decreasing = TRUE)
+  explainedVarOrder <- order(getR2(fittedFMM),decreasing = TRUE)
 
-  fittedFMM@A <- fittedFMM@A[explainedVarOrder]
-  fittedFMM@alpha <- fittedFMM@alpha[explainedVarOrder]
-  fittedFMM@beta <- fittedFMM@beta[explainedVarOrder]
-  fittedFMM@omega <- fittedFMM@omega[explainedVarOrder]
-  fittedFMM@R2 <- fittedFMM@R2[explainedVarOrder]
+  fittedFMM@A <- getA(fittedFMM)[explainedVarOrder]
+  fittedFMM@alpha <- getAlpha(fittedFMM)[explainedVarOrder]
+  fittedFMM@beta <- getBeta(fittedFMM)[explainedVarOrder]
+  fittedFMM@omega <- getOmega(fittedFMM)[explainedVarOrder]
+  fittedFMM@R2 <- getR2(fittedFMM)[explainedVarOrder]
 
   # Restricted algorithm may find models with A<0
-  needFix <- which(fittedFMM@A < 0)
+  needFix <- which(getA(fittedFMM) < 0)
   if(length(needFix)>0) {
     stop("Invalid solution: check function input parameters.")
   }

--- a/R/fitFMM_back.R
+++ b/R/fitFMM_back.R
@@ -22,7 +22,7 @@ fitFMM_back<-function(vData, nback, timePoints = seqTimes(length(vData)),
                                           length.out = lengthOmegaGrid)),
                       numReps = 3, showProgress = TRUE, usedApply = getApply(FALSE)[[1]]){
 
-  n <- length(vData)
+  nObs <- length(vData)
 
   if(showProgress){
     totalMarks <- 50
@@ -34,7 +34,7 @@ fitFMM_back<-function(vData, nback, timePoints = seqTimes(length(vData)),
   }
 
   # Object initialization.
-  fittedValuesPerComponent <- matrix(rep(0, n*nback), ncol = nback)
+  fittedValuesPerComponent <- matrix(rep(0, nObs*nback), ncol = nback)
   fittedFMMPerComponent <- list()
   prevFittedFMMvalues <- NULL
   stopCriteria <- "Stopped by reaching maximum iterations ("

--- a/R/fitFMM_back.R
+++ b/R/fitFMM_back.R
@@ -18,19 +18,16 @@ fitFMM_back<-function(vData, nback, timePoints = seqTimes(length(vData)),
                       lengthAlphaGrid = 48, lengthOmegaGrid = 24,
                       alphaGrid = seq(0, 2*pi, length.out = lengthAlphaGrid),
                       omegaMin = 0.0001, omegaMax = 1,
-                      omegaGrid = exp(seq(log(omegaMin),log(omegaMax),
-                                          length.out=lengthOmegaGrid)),
+                      omegaGrid = exp(seq(log(omegaMin), log(omegaMax),
+                                          length.out = lengthOmegaGrid)),
                       numReps = 3, showProgress = TRUE, usedApply = getApply(FALSE)[[1]]){
 
   n <- length(vData)
 
-  alphaGrid <- replicateGrid(grid = alphaGrid, nback = nback)
-  omegaGrid <- replicateGrid(grid = omegaGrid, nback = nback)
-
   if(showProgress){
     totalMarks <- 50
     partialMarkLength <- 2
-    progressHeader<-paste(c("|",rep("-",totalMarks),"|\n|"), collapse ="")
+    progressHeader<-paste(c("|", rep("-", totalMarks), "|\n|"), collapse = "")
     cat(progressHeader)
     completedPercentage <- 0.00001
     previousPercentage <- completedPercentage
@@ -40,9 +37,9 @@ fitFMM_back<-function(vData, nback, timePoints = seqTimes(length(vData)),
   fittedValuesPerComponent <- matrix(rep(0, n*nback), ncol = nback)
   fittedFMMPerComponent <- list()
   prevFittedFMMvalues <- NULL
+  stopCriteria <- "Stopped by reaching maximum iterations ("
 
   # Backfitting algorithm: iteration
-  stopCriteria<-"Stopped by reaching maximum iterations ("
   for(i in 1:maxiter){
     # Backfitting algorithm: component
     for(j in 1:nback){
@@ -51,8 +48,8 @@ fitFMM_back<-function(vData, nback, timePoints = seqTimes(length(vData)),
 
       # component j fitting using fitFMM_unit function
       fittedFMMPerComponent[[j]] <- fitFMM_unit(backFittingData, timePoints = timePoints, lengthAlphaGrid = lengthAlphaGrid,
-                                            lengthOmegaGrid = lengthOmegaGrid, alphaGrid = alphaGrid[[j]], omegaMin = omegaMin,
-                                            omegaMax = omegaMax, omegaGrid = omegaGrid[[j]], numReps = numReps, usedApply)
+                                            lengthOmegaGrid = lengthOmegaGrid, alphaGrid = alphaGrid, omegaMin = omegaMin,
+                                            omegaMax = omegaMax, omegaGrid = omegaGrid, numReps = numReps, usedApply)
       fittedValuesPerComponent[,j] <- fittedFMMPerComponent[[j]]@fittedValues
       # showProgress
       if(showProgress){
@@ -74,11 +71,11 @@ fitFMM_back<-function(vData, nback, timePoints = seqTimes(length(vData)),
       if(PV(vData, prevFittedFMMvalues) > PV(vData, fittedFMMvalues)){
         fittedFMMPerComponent <- previousFittedFMMPerComponent
         fittedFMMvalues <- prevFittedFMMvalues
-        stopCriteria<-"Stopped by reaching maximum R2 ("
+        stopCriteria <- "Stopped by reaching maximum R2 ("
         break
       }
       if(stopFunction(vData, fittedFMMvalues, prevFittedFMMvalues)){
-        stopCriteria<-"Stopped by the stopFunction ("
+        stopCriteria <- "Stopped by the stopFunction ("
         break
       }
     }
@@ -93,8 +90,7 @@ fitFMM_back<-function(vData, nback, timePoints = seqTimes(length(vData)),
       completedPercentage <- 100
       nMarks <- ifelse(ceiling(previousPercentage) < floor(completedPercentage),
                        sum((seq(ceiling(previousPercentage),
-                                floor(completedPercentage), by = 1) %% partialMarkLength == 0)),
-                       0)
+                                floor(completedPercentage), by = 1) %% partialMarkLength == 0)), 0)
       if (nMarks > 0) {
         cat(paste(rep("=",nMarks), collapse = ""))
         previousPercentage <- completedPercentage
@@ -108,7 +104,7 @@ fitFMM_back<-function(vData, nback, timePoints = seqTimes(length(vData)),
   omega <- unlist(lapply(fittedFMMPerComponent, getOmega))
 
   # A and M estimates are recalculated by linear regression; cosPhi is the design matrix
-  cosPhi <- calculateCosPhi(alpha=alpha, beta=beta, omega=omega, timePoints=timePoints)
+  cosPhi <- calculateCosPhi(alpha = alpha, beta = beta, omega = omega, timePoints = timePoints)
   linearModel <- lm(vData ~ cosPhi)
   M <- as.vector(linearModel$coefficients[1])
   A <- as.vector(linearModel$coefficients[-1])

--- a/R/fitFMM_back.R
+++ b/R/fitFMM_back.R
@@ -1,9 +1,9 @@
-###############################################################
+###########################################################################################
 # Internal function: fit multicomponent FMM model
 # Arguments:
 #   vData: data to be fitted an FMM model.
-#   timePoints: one single period time points.
 #   nback: number of FMM components to be fitted.
+#   timePoints: one single period time points.
 #   maxiter: maximum number of iterations for the backfitting algorithm.
 #   stopFunction: function to check the criterion convergence for the backfitting algorithm.
 #   lengthAlphaGrid, lengthOmegaGrid: precision of the grid of alpha and omega parameters.
@@ -12,7 +12,7 @@
 #   numReps: number of times the alpha-omega grid search is repeated.
 #   showProgress: TRUE to display a progress indicator on the console.
 # Returns an object of class FMM.
-###############################################################
+###########################################################################################
 fitFMM_back<-function(vData, nback, timePoints = seqTimes(length(vData)),
                       maxiter = nback, stopFunction = alwaysFalse,
                       lengthAlphaGrid = 48, lengthOmegaGrid = 24,
@@ -55,7 +55,7 @@ fitFMM_back<-function(vData, nback, timePoints = seqTimes(length(vData)),
       if(showProgress){
         completedPercentage <- completedPercentage + 100/(nback*maxiter)
         if(ceiling(previousPercentage) < floor(completedPercentage)){
-          progressDone<-paste(rep("=",sum((seq(ceiling(previousPercentage), floor(completedPercentage), by = 1)
+          progressDone <- paste(rep("=",sum((seq(ceiling(previousPercentage), floor(completedPercentage), by = 1)
                                            %% partialMarkLength == 0))), collapse = "")
           cat(progressDone)
           previousPercentage <- completedPercentage

--- a/R/fitFMM_back.R
+++ b/R/fitFMM_back.R
@@ -50,7 +50,7 @@ fitFMM_back<-function(vData, nback, timePoints = seqTimes(length(vData)),
       fittedFMMPerComponent[[j]] <- fitFMM_unit(backFittingData, timePoints = timePoints, lengthAlphaGrid = lengthAlphaGrid,
                                             lengthOmegaGrid = lengthOmegaGrid, alphaGrid = alphaGrid, omegaMin = omegaMin,
                                             omegaMax = omegaMax, omegaGrid = omegaGrid, numReps = numReps, usedApply)
-      fittedValuesPerComponent[,j] <- fittedFMMPerComponent[[j]]@fittedValues
+      fittedValuesPerComponent[,j] <- getFittedValues(fittedFMMPerComponent[[j]])
       # showProgress
       if(showProgress){
         completedPercentage <- completedPercentage + 100/(nback*maxiter)

--- a/R/fitFMM_restr.R
+++ b/R/fitFMM_restr.R
@@ -26,14 +26,12 @@ fitFMM_restr<-function(vData, nback, betaRestrictions, omegaRestrictions,
                        omegaGrid = exp(seq(log(omegaMin),log(omegaMax), length.out = lengthOmegaGrid)),
                        numReps = 3, parallelize = FALSE){
 
-  n <- length(vData)
   betaRestrictions <- sort(betaRestrictions)
   omegaRestrictions <- sort(omegaRestrictions)
-  alphaGrid <- replicateGrid(alphaGrid, nback = nback)
 
   # External grid of omega parameters
   numOmegas <- length(unique(omegaRestrictions))
-  listOmegas <- replicateGrid(omegaGrid, numOmegas)
+  listOmegas <- replicate(n = numOmegas, omegaGrid, simplify = FALSE)
   omegasIter <- expand.grid(listOmegas)[,omegaRestrictions]
 
   # External loop on the omega grid, setting its value
@@ -112,7 +110,7 @@ fitFMM_restr_omega_beta<-function(vData, nback, betaRestrictions, omegaRestricti
                                   alphaGrid = seq(0, 2*pi, length.out = lengthAlphaGrid), omegaMin = 0.0001, omegaMax = 1,
                                   omegaGrid = exp(seq(log(omegaMin),log(omegaMax), length.out=lengthOmegaGrid)),
                                   numReps = 3, showProgress = TRUE, parallelize = FALSE){
-  n <- length(vData)
+  nObs <- length(vData)
 
   # showProgress
   if(showProgress){
@@ -128,7 +126,7 @@ fitFMM_restr_omega_beta<-function(vData, nback, betaRestrictions, omegaRestricti
   numBlocks <- length(unique(omegaRestrictions))
 
   # Object initialization
-  fittedValuesPerBlock <- matrix(0, ncol = numBlocks, nrow = n)
+  fittedValuesPerBlock <- matrix(0, ncol = numBlocks, nrow = nObs)
   fittedFMMPerBlock <- list()
   prevFittedFMMvalues <- NULL
 

--- a/R/fitFMM_unit.R
+++ b/R/fitFMM_unit.R
@@ -18,7 +18,7 @@ fitFMM_unit <- function(vData, timePoints = seqTimes(length(vData)),
                                           length.out = lengthOmegaGrid)),
                       numReps = 3, usedApply = getApply(FALSE)[[1]]){
 
-  n <- length(vData)
+  nObs <- length(vData)
   grid <- expand.grid(alphaGrid, omegaGrid)
   step1OutputNames <- c("M","A","alpha","beta","omega","RSS")
 
@@ -40,7 +40,7 @@ fitFMM_unit <- function(vData, timePoints = seqTimes(length(vData)),
   nelderMead <- optim(par = bestPar[1:5], fn = step2FMM, vData = vData,
                       timePoints = timePoints, omegaMax = omegaMax)
   parFinal <- nelderMead$par
-  SSE <- nelderMead$value*n
+  SSE <- nelderMead$value*nObs
 
   # alpha and beta between 0 and 2pi
   parFinal[3] <- parFinal[3]%%(2*pi)

--- a/R/generateFMM.R
+++ b/R/generateFMM.R
@@ -54,57 +54,41 @@
 #' generateFMM(M = 0, A = 2, alpha = c(1.5, 3.4), beta = c(0.2, 2.3), omega = c(0.1, 0.2))
 #'
 #'
-generateFMM <- function(M,A,alpha,beta,omega,from=0,to=2*pi,length.out=100,timePoints=seq(from,to,length=length.out),
-                plot=TRUE,outvalues=TRUE,sigmaNoise=0){
+generateFMM <- function(M, A, alpha, beta, omega, from = 0, to = 2*pi, length.out = 100,
+                        timePoints = seq(from, to, length = length.out), plot=TRUE,
+                        outvalues = TRUE, sigmaNoise = 0){
 
-  narg <- max(length(M),length(A),length(alpha),length(beta),length(omega))
+  narg <- max(length(M), length(A), length(alpha), length(beta), length(omega))
 
   if(length(M)>1){
     warning("M parameter should be a vector of length 1.
             The intercept parameter used in the simulation is the sum of the elements of the argument M.")
     M <- sum(M)
   }
-  M <- rep(M/narg,length.out=narg)
 
+  A <- rep(A, length.out = narg)
+  if(sum(A <= 0) > 0) stop("'A' parameter must be positive.")
 
-  A <- rep(A,length.out=narg)
-  if(sum(A <= 0) > 0) stop("A parameter must be positive.")
-
-  alpha <- rep(alpha,length.out=narg)
+  alpha <- rep(alpha, length.out = narg)
   alpha <- alpha%%(2*pi) # between 0 and 2*pi
 
-  beta <- rep(beta,length.out=narg)
+  beta <- rep(beta, length.out = narg)
   beta <- beta%%(2*pi) # between 0 and 2*pi
 
-  omega <- rep(omega,length.out=narg)
-  if(sum(omega<0)>0 | sum(omega>1)>0) stop("omega parameter must be between 0 and 1.")
+  omega <- rep(omega, length.out = narg)
+  if(sum(omega<0)>0 | sum(omega>1)>0) stop("'omega' parameter must be between 0 and 1.")
 
-  t <- timePoints
+  y <- as.vector(A%*%t(calculateCosPhi(alpha = alpha, beta = beta, omega = omega,
+                             timePoints = timePoints)) + M)
 
-  phi <- list()
-  for(i in 1:narg){
-    phi[[i]] <- beta[i]+2*atan(omega[i]*tan((t-alpha[i])/2))
-  }
-
-  ym <- list()
-  for(i in 1:narg){
-    ym[[i]] <- M[i]+A[i]*cos(phi[[i]])
-  }
-
-  y <- rep(0,length(t))
-  for(i in 1:narg){
-    y <- y + ym[[i]]
-  }
-
-  if (sigmaNoise > 0) y <- y + rnorm(length.out,0,sigmaNoise)
+  if (sigmaNoise > 0) y <- y + rnorm(length.out, 0, sigmaNoise)
 
   if(plot) {
-    type_<-ifelse(sigmaNoise==0,"l","p")
-    plot(t,y,type=type_,lwd=2,col=2,xlab="Time",ylab="Response",
-                main=paste("Simulated data from FMM model"))
-
+    lineType <- ifelse(sigmaNoise == 0, "l", "p")
+    plot(timePoints, y, type = lineType, lwd = 2, col = 2, xlab = "Time", ylab = "Response",
+                main = paste("Simulated data from FMM model"))
   }
 
-
-  if(outvalues) return(list(input=list(M = M[1]*narg, A=A,alpha=alpha,beta=beta,omega=omega),t=t,y=y))
+  if(outvalues) return(list(input=list(M = M, A = A, alpha = alpha, beta = beta,
+                                       omega = omega), t = timePoints, y = y))
 }

--- a/R/generateFMM.R
+++ b/R/generateFMM.R
@@ -59,11 +59,16 @@ generateFMM <- function(M, A, alpha, beta, omega, from = 0, to = 2*pi, length.ou
                         outvalues = TRUE, sigmaNoise = 0){
 
   narg <- max(length(M), length(A), length(alpha), length(beta), length(omega))
+  minLength <- min(length(A), length(alpha), length(beta), length(omega))
 
   if(length(M)>1){
-    warning("M parameter should be a vector of length 1.
+    warning("'M' parameter should be a vector of length 1.
             The intercept parameter used in the simulation is the sum of the elements of the argument M.")
     M <- sum(M)
+  }
+
+  if(minLength != narg){
+    warning("'A', 'alpha', 'beta' and 'omega' parameters have different lengths.")
   }
 
   A <- rep(A, length.out = narg)

--- a/R/generateFMM.R
+++ b/R/generateFMM.R
@@ -58,40 +58,39 @@ generateFMM <- function(M, A, alpha, beta, omega, from = 0, to = 2*pi, length.ou
                         timePoints = seq(from, to, length = length.out), plot=TRUE,
                         outvalues = TRUE, sigmaNoise = 0){
 
-  narg <- max(length(M), length(A), length(alpha), length(beta), length(omega))
+  nArgs <- max(length(M), length(A), length(alpha), length(beta), length(omega))
   minLength <- min(length(A), length(alpha), length(beta), length(omega))
 
   if(length(M)>1){
-    warning("'M' parameter should be a vector of length 1.
-            The intercept parameter used in the simulation is the sum of the elements of the argument M.")
+    warning("'M' parameter should be a vector of length 1. Using as 'M' the sum of the specified argument.")
     M <- sum(M)
   }
 
-  if(minLength != narg){
+  if(minLength != nArgs){
     warning("'A', 'alpha', 'beta' and 'omega' parameters have different lengths.")
   }
 
-  A <- rep(A, length.out = narg)
+  A <- rep(A, length.out = nArgs)
   if(sum(A <= 0) > 0) stop("'A' parameter must be positive.")
 
-  alpha <- rep(alpha, length.out = narg)
+  alpha <- rep(alpha, length.out = nArgs)
   alpha <- alpha%%(2*pi) # between 0 and 2*pi
 
-  beta <- rep(beta, length.out = narg)
+  beta <- rep(beta, length.out = nArgs)
   beta <- beta%%(2*pi) # between 0 and 2*pi
 
-  omega <- rep(omega, length.out = narg)
-  if(sum(omega<0)>0 | sum(omega>1)>0) stop("'omega' parameter must be between 0 and 1.")
+  omega <- rep(omega, length.out = nArgs)
+  if(any(omega<0) | any(omega>1)) stop("'omega' parameter must be between 0 and 1.")
 
   y <- as.vector(A%*%t(calculateCosPhi(alpha = alpha, beta = beta, omega = omega,
-                             timePoints = timePoints)) + M)
+                                       timePoints = timePoints)) + M)
 
-  if (sigmaNoise > 0) y <- y + rnorm(length.out, 0, sigmaNoise)
+  if (sigmaNoise > 0) y <- y + rnorm(n = length.out, mean = 0, sd = sigmaNoise)
 
   if(plot) {
     lineType <- ifelse(sigmaNoise == 0, "l", "p")
-    plot(timePoints, y, type = lineType, lwd = 2, col = 2, xlab = "Time", ylab = "Response",
-                main = paste("Simulated data from FMM model"))
+    plot(timePoints, y, type = lineType, lwd = 2, col = 2, xlab = "Time",
+         ylab = "Response", main = paste("Simulated data from FMM model"))
   }
 
   if(outvalues) return(list(input=list(M = M, A = A, alpha = alpha, beta = beta,

--- a/R/getFMMPeaks.R
+++ b/R/getFMMPeaks.R
@@ -44,31 +44,29 @@ getFMMPeaks <- function(objFMM, timePointsIn2pi = TRUE) {
   omega <- getOmega(objFMM)
 
   data<- getData(objFMM)
-  if(getNPeriods(objFMM) > 1) data<-getSummarizedData(objFMM)
+  if(getNPeriods(objFMM) > 1) data <- getSummarizedData(objFMM)
 
   nData <- length(data)
-
-
   nComp <- length(alpha)
 
   # timePoints estimation
-  peakU<-(alpha+2*atan2(1/omega*sin(-beta/2),cos(-beta/2)))%%(2*pi)
-  peakL<-(alpha+2*atan2(1/omega*sin((pi-beta)/2),cos((pi-beta)/2)))%%(2*pi)
+  peakU <- (alpha + 2*atan2(1/omega*sin(-beta/2), cos(-beta/2))) %% (2*pi)
+  peakL <- (alpha + 2*atan2(1/omega*sin((pi-beta)/2), cos((pi-beta)/2))) %% (2*pi)
 
   if(timePointsIn2pi){
-    tpeakU<-peakU
-    tpeakL<-peakL
+    tpeakU <- peakU
+    tpeakL <- peakL
   }else{
-    tpeakU<-peakU*nData/(2*pi) + 1
-    tpeakL<-peakL*nData/(2*pi) + 1
+    tpeakU <- peakU*nData/(2*pi) + 1
+    tpeakL <- peakL*nData/(2*pi) + 1
   }
 
   # signal estimation
-  phU <- lapply(1:nComp,function(k) (peakU[k]-alpha)/2)
-  phL <- lapply(1:nComp,function(k) (peakL[k]-alpha)/2)
+  phU <- lapply(1:nComp, function(k) (peakU[k]-alpha)/2)
+  phL <- lapply(1:nComp, function(k) (peakL[k]-alpha)/2)
   ZU <- sapply(1:nComp, function(k) M+sum(A*cos(beta + 2*atan(omega*tan(phU[[k]])))))
   ZL <- sapply(1:nComp, function(k) M+sum(A*cos(beta + 2*atan(omega*tan(phL[[k]])))))
-  names(ZU)<-names(ZL)<-NULL
+  names(ZU) <- names(ZL) <- NULL
 
-  return(list(tpeakU=tpeakU, tpeakL=tpeakL, ZU=ZU, ZL=ZL))
+  return(list(tpeakU = tpeakU, tpeakL = tpeakL, ZU = ZU, ZL = ZL))
 }

--- a/R/getFMMPeaks.R
+++ b/R/getFMMPeaks.R
@@ -66,7 +66,7 @@ getFMMPeaks <- function(objFMM, timePointsIn2pi = TRUE) {
   phL <- lapply(1:nComp, function(k) (peakL[k]-alpha)/2)
   ZU <- sapply(1:nComp, function(k) M+sum(A*cos(beta + 2*atan(omega*tan(phU[[k]])))))
   ZL <- sapply(1:nComp, function(k) M+sum(A*cos(beta + 2*atan(omega*tan(phL[[k]])))))
-  names(ZU) <- names(ZL) <- NULL
+  names(ZU) <- NULL; names(ZL) <- NULL
 
   return(list(tpeakU = tpeakU, tpeakL = tpeakL, ZU = ZU, ZL = ZL))
 }

--- a/R/plotFMM.R
+++ b/R/plotFMM.R
@@ -145,8 +145,11 @@ plotFMM <- function(objFMM, components = FALSE, plotAlongPeriods = FALSE,
     } else {
       requireNamespace("ggplot2", quietly = TRUE)
 
-      adjustedModel <- ifelse(plotAlongPeriods, rep(getFittedValues(objFMM), nPeriods),
-                              getFittedValues(objFMM))
+      if(plotAlongPeriods){
+        adjustedModel<-rep(getFittedValues(objFMM),nPeriods)
+      }else{
+        adjustedModel<-getFittedValues(objFMM)
+      }
 
       fittedData <- data.frame("Time" = 1:nObs, "fitted_FMM" = adjustedModel, "Response" = vData)
 

--- a/R/plotFMM.R
+++ b/R/plotFMM.R
@@ -59,31 +59,31 @@
 plotFMM <- function(objFMM, components = FALSE, plotAlongPeriods = FALSE,
                     use_ggplot2 = FALSE, legendInComponentsPlot = TRUE, textExtra = ""){
 
-  nPeriods <- objFMM@nPeriods
+  nPeriods <- getNPeriods(objFMM)
   if(nPeriods > 1){
     if(plotAlongPeriods & !components){
-      vData <- objFMM@data
+      vData <- getData(objFMM)
     }else{
-      vData <- objFMM@summarizedData
+      vData <- getSummarizedData(objFMM)
     }
-  }else{vData <- objFMM@data}
+  }else{vData <- getData(objFMM)}
   nObs <- length(vData)
 
   if(plotAlongPeriods & !components){
-    timePoints <- objFMM@timePoints
+    timePoints <- getTimePoints(objFMM)
     timePoints <- rep(timePoints, nPeriods)
   }else{
-    timePoints <- objFMM@timePoints
+    timePoints <- getTimePoints(objFMM)
   }
 
-  col = 2:(length(objFMM@alpha)+1)
+  col = 2:(length(getAlpha(objFMM))+1)
 
   significantTimePoints <- round(c(1, nObs*0.25, nObs*0.5, nObs*0.75, nObs))
 
   # Components plot: if there is more than one period, just the data from the first period will be plotted
   if(components){
     title <- ifelse(textExtra != "", paste("Components FMM", textExtra, sep = " - "),"Components FMM")
-    nComponents <- length(objFMM@alpha)
+    nComponents <- length(getAlpha(objFMM))
     componentNames<-paste("Wave ", 1:nComponents, sep = "")
 
     predicted <- extractWaves(objFMM)
@@ -136,20 +136,19 @@ plotFMM <- function(objFMM, components = FALSE, plotAlongPeriods = FALSE,
     if(!use_ggplot2){
       plot(1:nObs, vData, xlab = "Time", ylab = "Response", main = title, xaxt = "n")
       if(plotAlongPeriods){
-        points(1:nObs, rep(objFMM@fittedValues, nPeriods), type = "l", col = 2, lwd = 2)
+        points(1:nObs, rep(getFittedValues(objFMM), nPeriods), type = "l", col = 2, lwd = 2)
       }else{
-        points(1:nObs, objFMM@fittedValues, type = "l", col = 2, lwd = 2)
+        points(1:nObs, getFittedValues(objFMM), type = "l", col = 2, lwd = 2)
       }
       axis(1, las = 1, at = significantTimePoints,
            labels = parse(text=paste("t[",significantTimePoints, "]", sep = "")))
     } else {
       requireNamespace("ggplot2", quietly = TRUE)
 
-      adjustedModel <- ifelse(plotAlongPeriods, rep(objFMM@fittedValues, nPeriods),
-                              objFMM@fittedValues)
+      adjustedModel <- ifelse(plotAlongPeriods, rep(getFittedValues(objFMM), nPeriods),
+                              getFittedValues(objFMM))
 
-      fittedData <- data.frame("Time" = 1:nObs, "fitted_FMM" = adjustedModel,
-                               "Response" = vData)
+      fittedData <- data.frame("Time" = 1:nObs, "fitted_FMM" = adjustedModel, "Response" = vData)
 
       plot <- ggplot2::ggplot(data = fittedData, ggplot2::aes_(x=~Time, y=~Response, color = 1)) +
         ggplot2::geom_point(size = 2, color = "grey65", shape = 21, stroke = 1.1) +

--- a/R/plotFMM.R
+++ b/R/plotFMM.R
@@ -56,123 +56,112 @@
 #'                    lengthAlphaGrid = 20,lengthOmegaGrid = 10)
 #' plotFMM(fittedFMM2, plotAlongPeriods = TRUE)
 
-plotFMM <- function(objFMM, components=FALSE, plotAlongPeriods=FALSE,
-                    use_ggplot2=FALSE, legendInComponentsPlot = TRUE, textExtra = ""){
+plotFMM <- function(objFMM, components = FALSE, plotAlongPeriods = FALSE,
+                    use_ggplot2 = FALSE, legendInComponentsPlot = TRUE, textExtra = ""){
 
-  nPeriods=getNPeriods(objFMM)
-  if(nPeriods>1){
+  nPeriods <- objFMM@nPeriods
+  if(nPeriods > 1){
     if(plotAlongPeriods & !components){
-      vData <- getData(objFMM)
+      vData <- objFMM@data
     }else{
-      vData <- getSummarizedData(objFMM)
+      vData <- objFMM@summarizedData
     }
-  }else{vData <- getData(objFMM)}
-  nObs<-length(vData)
+  }else{vData <- objFMM@data}
+  nObs <- length(vData)
 
   if(plotAlongPeriods & !components){
-    timePoints <- getTimePoints(objFMM)
-    timePoints <- rep(timePoints,nPeriods)
+    timePoints <- objFMM@timePoints
+    timePoints <- rep(timePoints, nPeriods)
   }else{
-    timePoints <- getTimePoints(objFMM)
+    timePoints <- objFMM@timePoints
   }
 
-  col = 2:(length(getAlpha(objFMM))+1)
+  col = 2:(length(objFMM@alpha)+1)
 
-
-  significantTimePoints<-round(c(1,nObs*0.25, nObs*0.5, nObs*0.75, nObs))
+  significantTimePoints <- round(c(1, nObs*0.25, nObs*0.5, nObs*0.75, nObs))
 
   # Components plot: if there is more than one period, just the data from the first period will be plotted
   if(components){
-    title <- ifelse(textExtra != "", paste("Components FMM",textExtra,sep = " - "),"Components FMM")
-    nComponents <- length(getAlpha(objFMM))
-    componentNames<-paste("Wave ",1:nComponents, sep="")
+    title <- ifelse(textExtra != "", paste("Components FMM", textExtra, sep = " - "),"Components FMM")
+    nComponents <- length(objFMM@alpha)
+    componentNames<-paste("Wave ", 1:nComponents, sep = "")
 
-    predicted<-extractWaves(objFMM)
+    predicted <- extractWaves(objFMM)
 
-    minValue <- min(sapply(predicted,min))
-    maxValue <- max(sapply(predicted,max))
+    minValue <- min(sapply(predicted, min))
+    maxValue <- max(sapply(predicted, max))
 
     if(!use_ggplot2){
-      plot(1:nObs,vData,ylim=c(minValue,maxValue),xlab="Time",ylab="Response",main=title,type="n",xaxt = "n")
+      plot(1:nObs, vData, ylim = c(minValue, maxValue), xlab = "Time", ylab = "Response",
+           main = title, type = "n", xaxt = "n")
       for(i in 1:nComponents){
-        points(1:nObs,predicted[[i]],type="l",lwd=2,col=col[i])
+        points(1:nObs, predicted[[i]], type = "l", lwd = 2, col = col[i])
       }
-      axis(1, las = 1,
-           at = significantTimePoints,
+      axis(1, las = 1, at = significantTimePoints,
            labels = parse(text=paste("t[",significantTimePoints, "]", sep = "")))
-      if(legendInComponentsPlot) legend("topright",legend=componentNames,col=col,lty=1)
+      if(legendInComponentsPlot) legend("topright", legend = componentNames, col = col, lty = 1)
     } else {
       requireNamespace("ggplot2", quietly = TRUE)
       requireNamespace("RColorBrewer", quietly = TRUE)
 
-      df<-data.frame("Time"=rep(1:length(timePoints),nComponents),
-                     "Response"=unlist(predicted),
-                     "Components"=rep(componentNames,each=nObs))
+      df <- data.frame("Time" = rep(1:length(timePoints), nComponents),
+                       "Response" = unlist(predicted),
+                       "Components" = rep(componentNames, each = nObs))
 
       # With more than 9 components, the selection of colors must be expanded
-      if(nComponents>9){
+      if(nComponents > 9){
         colorsForComponents <- grDevices::colorRampPalette(RColorBrewer::brewer.pal(9, "Set1"))(nComponents)
       }else{
-        colorsForComponents <- ifelse(rep(nComponents>3,nComponents),RColorBrewer::brewer.pal(nComponents, "Set1"),RColorBrewer::brewer.pal(3, "Set1"))
+        colorsForComponents <- ifelse(rep(nComponents>3,nComponents),
+                                      RColorBrewer::brewer.pal(nComponents, "Set1"),
+                                      RColorBrewer::brewer.pal(3, "Set1"))
       }
 
-      plot<-ggplot2::ggplot(data=df, ggplot2::aes_(x=~Time, y=~Response,
-                                                  group=~Components, color=~Components)) +
-        ggplot2::geom_line(ggplot2::aes_(color=~Components),
-                  size=1.3,lineend = "round",linejoin = "round")+
-        ggplot2::scale_color_manual(values=colorsForComponents)+
-        ggplot2::theme_bw()+
-        ggplot2::theme(legend.position = ifelse(legendInComponentsPlot,"bottom","none"))+
-        ggplot2::labs(title = title)+
-        ggplot2::scale_x_continuous(
-          breaks = significantTimePoints,
-          labels = function(x) parse(text=paste("t[",x,"]")))
+      plot<-ggplot2::ggplot(data = df, ggplot2::aes_(x=~Time, y=~Response, group =~ Components,
+                                                     color =~ Components)) +
+        ggplot2::geom_line(ggplot2::aes_(color =~ Components),
+                           size=1.3,lineend = "round",linejoin = "round") +
+        ggplot2::scale_color_manual(values = colorsForComponents) +
+        ggplot2::theme_bw() +
+        ggplot2::theme(legend.position = ifelse(legendInComponentsPlot,"bottom","none")) +
+        ggplot2::labs(title = title) +
+        ggplot2::scale_x_continuous(breaks = significantTimePoints,
+                                    labels = function(x) parse(text=paste("t[",x,"]")))
       return(plot)
-
     }
 
   } else {
     title <- ifelse(textExtra != "", paste("Fitted FMM model",textExtra,sep = " - "),"Fitted FMM model")
 
     if(!use_ggplot2){
-      plot(1:nObs,vData,xlab="Time",ylab="Response",main=title,xaxt = "n")
+      plot(1:nObs, vData, xlab = "Time", ylab = "Response", main = title, xaxt = "n")
       if(plotAlongPeriods){
-        points(1:nObs,rep(getFittedValues(objFMM),nPeriods),type="l",col=2,lwd=2)
+        points(1:nObs, rep(objFMM@fittedValues, nPeriods), type = "l", col = 2, lwd = 2)
       }else{
-        points(1:nObs,getFittedValues(objFMM),type="l",col=2,lwd=2)
+        points(1:nObs, objFMM@fittedValues, type = "l", col = 2, lwd = 2)
       }
-      axis(1, las = 1,
-           at = significantTimePoints,
+      axis(1, las = 1, at = significantTimePoints,
            labels = parse(text=paste("t[",significantTimePoints, "]", sep = "")))
     } else {
       requireNamespace("ggplot2", quietly = TRUE)
 
-      if(plotAlongPeriods){
-        adjustedModel<-rep(getFittedValues(objFMM),nPeriods)
-      }else{
-        adjustedModel<-getFittedValues(objFMM)
-      }
+      adjustedModel <- ifelse(plotAlongPeriods, rep(objFMM@fittedValues, nPeriods),
+                              objFMM@fittedValues)
 
-      fittedData<-data.frame("Time"=1:nObs,
-                             "fitted_FMM"=adjustedModel,
-                             "Response"=vData)
+      fittedData <- data.frame("Time" = 1:nObs, "fitted_FMM" = adjustedModel,
+                               "Response" = vData)
 
-      plot<-ggplot2::ggplot(data=fittedData,
-                            ggplot2::aes_(x=~Time, y=~Response, color=1)) +
-        ggplot2::geom_point(size=2,color="grey65", shape=21, stroke=1.1)+
-        ggplot2::geom_path(ggplot2::aes_(x=~Time, y=~fitted_FMM, color="FMM", position=NULL),
-                  size=2,lineend = "round",linejoin = "round")+
-        ggplot2::labs(title = title)+
-        ggplot2::scale_color_manual(values="red")+
-        ggplot2::theme_bw()+
-        ggplot2::theme(legend.position = "none")+
-        ggplot2::scale_x_continuous(
-          breaks = significantTimePoints,
-          labels = function(x) parse(text=paste("t[",x,"]")))
-
+      plot <- ggplot2::ggplot(data = fittedData, ggplot2::aes_(x=~Time, y=~Response, color = 1)) +
+        ggplot2::geom_point(size = 2, color = "grey65", shape = 21, stroke = 1.1) +
+        ggplot2::geom_path(ggplot2::aes_(x=~Time, y=~fitted_FMM, color = "FMM", position = NULL),
+                           size=2, lineend = "round", linejoin = "round")+
+        ggplot2::labs(title = title) +
+        ggplot2::scale_color_manual(values = "red") +
+        ggplot2::theme_bw() +
+        ggplot2::theme(legend.position = "none") +
+        ggplot2::scale_x_continuous(breaks = significantTimePoints,
+                                    labels = function(x) parse(text = paste("t[",x,"]")))
       return(plot)
     }
-
   }
-
 }

--- a/R/plotFMM.R
+++ b/R/plotFMM.R
@@ -88,11 +88,9 @@ plotFMM <- function(objFMM, components = FALSE, plotAlongPeriods = FALSE,
 
     predicted <- extractWaves(objFMM)
 
-    minValue <- min(sapply(predicted, min))
-    maxValue <- max(sapply(predicted, max))
-
     if(!use_ggplot2){
-      plot(1:nObs, vData, ylim = c(minValue, maxValue), xlab = "Time", ylab = "Response",
+      yLimits<-c(min(sapply(predicted, min)), max(sapply(predicted, max)))
+      plot(1:nObs, vData, ylim = yLimits, xlab = "Time", ylab = "Response",
            main = title, type = "n", xaxt = "n")
       for(i in 1:nComponents){
         points(1:nObs, predicted[[i]], type = "l", lwd = 2, col = col[i])

--- a/R/stopFunctions.R
+++ b/R/stopFunctions.R
@@ -20,7 +20,7 @@ alwaysFalse <- function(vData, pred, prevPred){
 
 ################################################################################
 # Internal function: to check if the convergence criterion based on the
-#                    difference between theexplained variability in two
+#                    difference between the explained variability in two
 #                    consecutive iterations, is reached.
 # Arguments:
 #   vData: data to be fitted an FMM model.
@@ -34,7 +34,7 @@ R2 <- function(vData,pred,prevPred,difMax = 0.001){
   usedStopFunction <- function(vData, pred, prevPred){
     prevR2 <- PV(vData, prevPred)
     R2 <- PV(vData, pred)
-    R2diff <- R2 - prevR2
+    R2dif <- R2 - prevR2
     return(R2dif < difMax)
   }
   return(usedStopFunction)

--- a/R/stopFunctions.R
+++ b/R/stopFunctions.R
@@ -1,27 +1,27 @@
-###############################################################
-# Internal functions to check the criterion convergence for the backfitting algorithm.
+################################################################################
+# Internal functions to check the criterion convergence for the backfitting
+#   algorithm.
 # Functions:
 #   alwaysFalse:  returns FALSE to force maxiter iterations.
 #   R2: check the converge criterion based on explained variability.
-###############################################################
+################################################################################
 
-###############################################################
+################################################################################
 # Internal function: FALSE
 # Arguments:
 #   vData: data to be fitted an FMM model.
 #   pred: fitted values from current iteration.
 #   prevPred: fitted values from previous iteration
 # Returns FALSE to force maxiter iterations.
-###############################################################
-alwaysFalse <- function(vData,pred,prevPred){
+################################################################################
+alwaysFalse <- function(vData, pred, prevPred){
   return(FALSE)
 }
 
-###############################################################
-# Internal function: to check if the convergence criterion
-#                    based on the difference between the
-#                    explained variability in two consecutive
-#                    iterations, is reached.
+################################################################################
+# Internal function: to check if the convergence criterion based on the
+#                    difference between theexplained variability in two
+#                    consecutive iterations, is reached.
 # Arguments:
 #   vData: data to be fitted an FMM model.
 #   pred: fitted values from current iteration.
@@ -29,16 +29,14 @@ alwaysFalse <- function(vData,pred,prevPred){
 #   difMax: smallest observable difference between iterations
 #           to stop backfitting algorithm.
 # Returns TRUE when the converge criterion is reached.
-###############################################################
+################################################################################
 R2 <- function(vData,pred,prevPred,difMax = 0.001){
-  funDevolver <- function(vData,pred,prevPred){
-    R2.prev <- PV(vData,prevPred)
-    R2.now <- PV(vData,pred)
-    R2.dif <- R2.now - R2.prev
-
-    if(R2.dif < difMax) return(TRUE)
-    return(FALSE)
+  usedStopFunction <- function(vData, pred, prevPred){
+    prevR2 <- PV(vData, prevPred)
+    R2 <- PV(vData, pred)
+    R2diff <- R2 - prevR2
+    return(R2dif < difMax)
   }
-  return(funDevolver)
+  return(usedStopFunction)
 }
 

--- a/man/FMM-internal.Rd
+++ b/man/FMM-internal.Rd
@@ -17,7 +17,7 @@
 \alias{alwaysFalse}
 \alias{PV}
 \alias{PVj}
-\alias{angularmean}
+\alias{angularMean}
 \alias{seqTimes}
 \alias{calculateCosPhi}
 \alias{getApply}
@@ -35,7 +35,7 @@ To fit a single 'FMM' component: The functions \code{step1FMM()}, \code{bestStep
 
 To check the convergence criterion for the backfitting algorithm: \code{alwaysFalse()} is used to force a number of iterations while \code{R2()} is used to check if the stop condition, based on the difference between the variability explained in two consecutive iterations, is reached.
 
-Additional functions: The functions \code{PV()}, \code{PVj()}, \code{angularmean()} and \code{calculateCosPhi()} are used in the fitting process to compute the total percentage of variability explained, the percentage of variability explained by each component of 'FMM' model, the angular mean and the cosinus of each of the waves phase,respectively. \code{seqTimes()} is used to build a sequence of equally time points spaced in range \eqn{[0, 2\pi]}. \code{replicateGrid()} serves to create the grid of values for the parameters to be studied whereas \code{getApply()} serves to prepare the parallelized estimation procedure.
+Additional functions: The functions \code{PV()}, \code{PVj()}, \code{angularMean()} and \code{calculateCosPhi()} are used in the fitting process to compute the total percentage of variability explained, the percentage of variability explained by each component of 'FMM' model, the angular mean and the cosinus of each of the waves phase,respectively. \code{seqTimes()} is used to build a sequence of equally time points spaced in range \eqn{[0, 2\pi]}. \code{replicateGrid()} serves to create the grid of values for the parameters to be studied whereas \code{getApply()} serves to prepare the parallelized estimation procedure.
 
 }
 
@@ -57,7 +57,7 @@ Depending on the returned value:
    }
    \item{\code{step2FMM()}, \code{step2FMM_restr()} and \code{stepOmega()} return a numerical value with residual
          sum of squares of a possible solution. \code{PV()} returns the total percentage of variability explained
-         by the model. \code{angularmean()} returns the angular mean of the input angles.
+         by the model. \code{angularMean()} returns the angular mean of the input angles.
    }
     \item{\code{R2()} and \code{alwaysFalse()} return a logical value. \code{alwaysFalse()} always returns
           \code{FALSE} while \code{R2()} returns \code{TRUE} when the convergence criterion is reached.

--- a/man/FMM-internal.Rd
+++ b/man/FMM-internal.Rd
@@ -34,7 +34,7 @@ To fit a single 'FMM' component: The functions \code{step1FMM()}, \code{bestStep
 
 To check the convergence criterion for the backfitting algorithm: \code{alwaysFalse()} is used to force a number of iterations while \code{R2()} is used to check if the stop condition, based on the difference between the variability explained in two consecutive iterations, is reached.
 
-Additional functions: The functions \code{PV()}, \code{PVj()}, \code{angularMean()} and \code{calculateCosPhi()} are used in the fitting process to compute the total percentage of variability explained, the percentage of variability explained by each component of 'FMM' model, the angular mean and the cosinus of each of the waves phase,respectively. \code{seqTimes()} is used to build a sequence of equally time points spaced in range \eqn{[0, 2\pi]}. \code{replicateGrid()} serves to create the grid of values for the parameters to be studied whereas \code{getApply()} serves to prepare the parallelized estimation procedure.
+Additional functions: The functions \code{PV()}, \code{PVj()}, \code{angularMean()} and \code{calculateCosPhi()} are used in the fitting process to compute the total percentage of variability explained, the percentage of variability explained by each component of 'FMM' model, the angular mean and the cosinus of each of the waves phase,respectively. \code{seqTimes()} is used to build a sequence of equally time points spaced in range \eqn{[0, 2\pi]}. \code{getApply()} serves to prepare the parallelized estimation procedure.
 
 }
 

--- a/man/FMM-internal.Rd
+++ b/man/FMM-internal.Rd
@@ -21,7 +21,6 @@
 \alias{seqTimes}
 \alias{calculateCosPhi}
 \alias{getApply}
-\alias{replicateGrid}
 \alias{addShowMethod}
 
 \title{Internal functions for the 'FMM' package.}


### PR DESCRIPTION
## Files General Review

> ### 1. FMM fitting files.
#### 1.1 FMM_internal.R
- `replicateGrid` function deleted due to a change in the way to define grids: grids won't change along function calls or depending on backfitting iterations, so only a vector is necessary. Also deleted in `FMM_internal.rd` file.
- `PV` and `PVj` function rewritten (just more compacted code than before).
- `seqTimes` and `angularMean` functions (only a few rewritten lines).
#### 1.2 fitFMM_unit.R
- Checked. No changes.
#### 1.3 fitFMM_back.R
- `replicateGrid` function is not used (see `replicateGrid` above).
#### 1.4 fitFMM.R
- `getApply` is used as supposed. These lines were altered due to restricted FMM fitting problems with parallelization, but it has been fixed.
> ### 2. Other FMM files and functions.
#### 2.1 stopFunctions.R
- in `R2` function, only a few rewritten lines.
#### 2.2 generateFMM.R
- fitted FMM values computation compacted.
- `A`, `alpha`, `beta` and `omega` vector lengths can be not equal: now a **warning** is thrown if those vectors have not the same length.
#### 2.3 plotFMM.R
- Checked. No changes.
#### 2.4 extractWaves.R
- Variable names changed. 
- Use of calculateCosPhi to compute model values.
#### 2.5 getFMMPeaks.R
- Checked. No changes.
> ### 3. FMM class and methods:
- `Class.R` and `FMM-methods.R` checked. No changes.
> ### 4. Other changes.
- Object member access operator (`@`) is used when preparing final FMM object at `fitFMM` function.
- Restricted FMM model fitting has been checked at the previous version (fitFMM_restr.R and FMM_internal_restr).